### PR TITLE
Crypt methods

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -7,7 +7,7 @@ class Enigma
     keys = key_manager(key)
     offsets = date_manager(date)
     shifts = shift(keys, offsets)
-    cipher = encode(message, shifts)
+    cipher = code(message, shifts)
     {
       encryption: cipher.join,
       key: keys.values.to_s.gsub(/., |\[|\]/, '').rjust(5, '0'),
@@ -15,8 +15,17 @@ class Enigma
     }
   end
 
-  # def decrypt(message, key, date = nil)
-  # end
+  def decrypt(cipher, key, date = nil)
+    keys = key_manager(key)
+    offsets = date_manager(date)
+    shifts = shift(keys, offsets)
+    message = code(cipher, shifts, -1)
+    {
+      message: message.join,
+      key: keys.values.to_s.gsub(/., |\[|\]/, '').rjust(5, '0'),
+      date: date ||= date_gen
+    }
+  end
 
   # def crack
   # end
@@ -58,7 +67,7 @@ class Enigma
     date.strftime("%d%m%y")
   end
 
-  def encode(message, shifts)
+  def code(message, shifts, dir = 1)
     char_set = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", " "]
     msg_chars = message.downcase.split('')
     keys = %w[A B C D]
@@ -66,9 +75,16 @@ class Enigma
       shft_index = msg_index % 4
       if char_set.include?(char)
         char_id = char_set.find_index(char)
-        msg_chars[msg_index] = char_set[(char_id + shifts[keys[shft_index]]) % 27]
+        msg_chars[msg_index] = char_set[(char_id + (dir * shifts[keys[shft_index]])) % 27]
       end
     end
-    msg_chars
+  end
+
+  def format(text, keys, date)
+    {
+      message: text.join,
+      key: keys.values.to_s.gsub(/., |\[|\]/, '').rjust(5, '0'),
+      date: date ||= date_gen
+    }
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,16 +1,24 @@
+require 'date'
+
 class Enigma
-def encrypt(message, key = nil, date = nil)
-  
-end
+  def encrypt(message, key = nil, date = nil)
+   
+  end
 
-# def decrypt(message, key, date = nil)
-# end
+  # def decrypt(message, key, date = nil)
+  # end
 
-# def crack
-# end
+  # def crack
+  # end
 
-private
+  private
 
-def key_gen
-  Random.new.rand(99999).to_s.rjust(5, '0')
-end
+  def key_gen
+    Random.new.rand(99999).to_s.rjust(5, '0')
+  end
+
+  def date_gen
+    date = Time.new
+    date.strftime("%d%m%y")
+  end
+    

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,8 +1,21 @@
 require 'date'
+require 'pry'
 
 class Enigma
+  def initialize
+  end
+  
   def encrypt(message, key = nil, date = nil)
-   
+    keys = key_manager(key)
+    offsets = date_manager(date)
+    shifts = shift(keys, offsets)
+    #binding.pry
+    cipher = encode(message, shifts)
+    {
+      encryption: cipher.join,
+      key: keys.values.to_s.gsub(/., |\[|\]/,'').rjust(5,'0'),
+      date: date ||= date_gen
+    }
   end
 
   # def decrypt(message, key, date = nil)
@@ -13,12 +26,56 @@ class Enigma
 
   private
 
+  def shift(keys, offsets)
+    Hash[keys.map { |k, v| [k, v + offsets[k]] }]
+  end
+
+  def key_manager(key)
+    key ||= key_gen
+    key = key.to_s.rjust(5, '0')
+    index = 0
+    %w[A B C D].reduce(Hash.new('')) do |hash, letter|
+      hash[letter] = key[index..index + 1].to_i
+      index += 1
+      hash
+    end
+  end
+
+  def date_manager(date)
+    date ||= date_gen
+    date = (date.to_i**2).to_s[-4..-1]
+    index = 0
+    #binding.pry
+    %w[A B C D].reduce(Hash.new('')) do |hash, letter|
+      hash[letter] = date[index].to_i
+      index += 1
+      hash
+    end
+  end
+
   def key_gen
-    Random.new.rand(99999).to_s.rjust(5, '0')
+    Random.new.rand(99999)
   end
 
   def date_gen
     date = Time.new
     date.strftime("%d%m%y")
   end
+
+  def encode(message, shifts)
+    char_set = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", " "]
+    msg_chars = message.downcase.split('')
+    keys = %w[A B C D]
+    msg_index = 0
     
+    msg_chars.each do |char|
+      shft_index = msg_index % 4
+      if char_set.include?(char)
+        char_id = char_set.find_index(char)
+        msg_chars[msg_index] = char_set[(char_id + shifts[keys[shft_index]]) % 27]
+      end
+      msg_index += 1
+    end
+    msg_chars
+  end
+end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -79,12 +79,4 @@ class Enigma
       end
     end
   end
-
-  def format(text, keys, date)
-    {
-      message: text.join,
-      key: keys.values.to_s.gsub(/., |\[|\]/, '').rjust(5, '0'),
-      date: date ||= date_gen
-    }
-  end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -2,18 +2,15 @@ require 'date'
 require 'pry'
 
 class Enigma
-  def initialize
-  end
-  
+
   def encrypt(message, key = nil, date = nil)
     keys = key_manager(key)
     offsets = date_manager(date)
     shifts = shift(keys, offsets)
-    #binding.pry
     cipher = encode(message, shifts)
     {
       encryption: cipher.join,
-      key: keys.values.to_s.gsub(/., |\[|\]/,'').rjust(5,'0'),
+      key: keys.values.to_s.gsub(/., |\[|\]/, '').rjust(5, '0'),
       date: date ||= date_gen
     }
   end
@@ -45,7 +42,6 @@ class Enigma
     date ||= date_gen
     date = (date.to_i**2).to_s[-4..-1]
     index = 0
-    #binding.pry
     %w[A B C D].reduce(Hash.new('')) do |hash, letter|
       hash[letter] = date[index].to_i
       index += 1
@@ -54,7 +50,7 @@ class Enigma
   end
 
   def key_gen
-    Random.new.rand(99999)
+    Random.new.rand(99_999)
   end
 
   def date_gen
@@ -66,15 +62,12 @@ class Enigma
     char_set = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", " "]
     msg_chars = message.downcase.split('')
     keys = %w[A B C D]
-    msg_index = 0
-    
-    msg_chars.each do |char|
+    msg_chars.each_with_index do |char, msg_index = 0|
       shft_index = msg_index % 4
       if char_set.include?(char)
         char_id = char_set.find_index(char)
         msg_chars[msg_index] = char_set[(char_id + shifts[keys[shft_index]]) % 27]
       end
-      msg_index += 1
     end
     msg_chars
   end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,3 +1,16 @@
 class Enigma
+def encrypt(message, key = nil, date = nil)
+  
+end
 
+# def decrypt(message, key, date = nil)
+# end
+
+# def crack
+# end
+
+private
+
+def key_gen
+  Random.new.rand(99999).to_s.rjust(5, '0')
 end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Enigma do
       })
     end
 
+    it 'can encrypt a message with a special character' do
+      expect(@enigma.encrypt('hello world!', '02715', '040895')).to eq(
+      {
+        encryption: 'keder ohulw!',
+        key: '02715',
+        date: '040895'
+      })
+    end
+
     it "can encrypt a message with a key (uses today's date)" do
       allow(@enigma).to receive(:date_gen) { '060822' }
       expect(@enigma.encrypt('hello world', '02715')).to eq(
@@ -74,26 +83,26 @@ RSpec.describe Enigma do
     end
   end
 
-  # describe '#decrypt' do
-  #   it 'can decrypt a message with a key and date' do
-  #     expect(@enigma.decrypt('keder ohulw', '02715', '040895')).to eq
-  #     {
-  #       encryption: 'hello world',
-  #       key: '02715',
-  #       date: '040895'
-  #     }
-  #   end
+  describe '#decrypt' do
+    it 'can decrypt a message with a key and date' do
+      expect(@enigma.decrypt('keder ohulw', '02715', '040895')).to eq(
+      {
+        message: 'hello world',
+        key: '02715',
+        date: '040895'
+      })
+    end
 
-  #   it "can decrypt a message with a key (uses today's date)" do
-  #     encrypted = @enigma.encrypt('hello world', '02715')
-  #     expect(@enigma.decrypt(encrypted[:encryption], '02715')).to eq
-  #     {
-  #       encryption: 'hello world',
-  #       key: '02715',
-  #       date: '040895'
-  #     }
-  #   end
-  # end
+    it "can decrypt a message with a key (uses today's date)" do
+      encrypted = @enigma.encrypt('hello world', '02715')
+      expect(@enigma.decrypt(encrypted[:encryption], '02715')).to eq(
+      {
+        message: 'hello world',
+        key: '02715',
+        date: @date
+      })
+    end
+  end
 
   # describe '#crack' do
   # end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -3,57 +3,76 @@ require_relative '../lib/enigma'
 RSpec.describe Enigma do
   before(:each) do
     @enigma = Enigma.new
+    @date = Time.new.strftime("%d%m%y")
   end
 
   describe '#encrypt' do
     it 'can encrypt a message with a key and date' do
-      expect(@enigma.encrypt('hello world', '02715', '040895')).to eq 
+      expect(@enigma.encrypt('hello world', '02715', '040895')).to eq(
       {
         encryption: 'keder ohulw',
         key: '02715',
         date: '040895'
-      }
+      })
     end
 
     it "can encrypt a message with a key (uses today's date)" do
-      expect(@enigma.enigma.encrypt('hello world', '02715')).to eq 
+      allow(@enigma).to receive(:date_gen) { '060822' }
+      expect(@enigma.encrypt('hello world', '02715')).to eq(
+      {
+        encryption: 'okjdvfugyrb',
+        key: '02715',
+        date: '060822'
+      })
+      allow(@enigma).to receive(:date_gen) { '040895' }
+      expect(@enigma.encrypt('hello world', '02715')).to eq(
       {
         encryption: 'keder ohulw',
         key: '02715',
         date: '040895'
-      }
+      })
     end
 
     it "can encrypt a message (generates random key and uses today's date)" do
-      expect(@enigma.encrypt('hello world')).to eq
+      allow(@enigma).to receive(:key_gen) { 2715 }
+      allow(@enigma).to receive(:date_gen) { '060822' }
+      expect(@enigma.encrypt('hello world')).to eq(
+      {
+        encryption: 'okjdvfugyrb',
+        key: '02715',
+        date: '060822'
+      })
+      allow(@enigma).to receive(:key_gen) { 2715 }
+      allow(@enigma).to receive(:date_gen) { '040895' }
+      expect(@enigma.encrypt('hello world')).to eq(
       {
         encryption: 'keder ohulw',
         key: '02715',
         date: '040895'
-      }
+      })
     end
   end
 
-  describe '#decrypt' do
-    it 'can decrypt a message with a key and date' do
-      expect(@enigma.decrypt('keder ohulw', '02715', '040895')).to eq
-      {
-        encryption: 'hello world',
-        key: '02715',
-        date: '040895'
-      }
-    end
+  # describe '#decrypt' do
+  #   it 'can decrypt a message with a key and date' do
+  #     expect(@enigma.decrypt('keder ohulw', '02715', '040895')).to eq
+  #     {
+  #       encryption: 'hello world',
+  #       key: '02715',
+  #       date: '040895'
+  #     }
+  #   end
 
-    it "can decrypt a message with a key (uses today's date)" do
-      encrypted = @enigma.encrypt('hello world', '02715')
-      expect(@enigma.decrypt(encrypted[:encryption], '02715')).to eq
-      {
-        encryption: 'hello world',
-        key: '02715',
-        date: '040895'
-      }
-    end
-  end
+  #   it "can decrypt a message with a key (uses today's date)" do
+  #     encrypted = @enigma.encrypt('hello world', '02715')
+  #     expect(@enigma.decrypt(encrypted[:encryption], '02715')).to eq
+  #     {
+  #       encryption: 'hello world',
+  #       key: '02715',
+  #       date: '040895'
+  #     }
+  #   end
+  # end
 
   # describe '#crack' do
   # end

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Enigma do
     end
 
     it "can encrypt a message (generates random key and uses today's date)" do
-      expect(enigma.encrypt('hello world')).to eq
+      expect(@enigma.encrypt('hello world')).to eq
       {
         encryption: 'keder ohulw',
         key: '02715',
@@ -45,7 +45,7 @@ RSpec.describe Enigma do
     end
 
     it "can decrypt a message with a key (uses today's date)" do
-      encrypted = enigma.encrypt('hello world', '02715')
+      encrypted = @enigma.encrypt('hello world', '02715')
       expect(@enigma.decrypt(encrypted[:encryption], '02715')).to eq
       {
         encryption: 'hello world',

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -1,3 +1,4 @@
+
 require_relative '../lib/enigma'
 
 RSpec.describe Enigma do
@@ -50,6 +51,26 @@ RSpec.describe Enigma do
         key: '02715',
         date: '040895'
       })
+    end
+
+    describe 'helper methods' do 
+      it 'key_gen generates random 5 digit number' do
+        range = []
+        10000.times do 
+          range << @enigma.send(:key_gen)
+        end
+        expect(range.max > 0).to be true
+        expect(range.min < 100000).to be true
+      end
+
+      it 'date_gen generate dates in a DDMMYY digit format' do 
+        time = Time.new
+        date = @enigma.send(:date_gen)
+        expect(date.length).to eq(6)
+        expect(date[0..1]).to eq(time.day.to_s.rjust(2,"0"))
+        expect(date[2..3]).to eq(time.month.to_s.rjust(2,"0"))
+        expect(date[4..5]).to eq(time.year.to_s[-2..-1])
+      end
     end
   end
 

--- a/spec/enigma_spec.rb
+++ b/spec/enigma_spec.rb
@@ -1,3 +1,60 @@
 require_relative '../lib/enigma'
 
-Rspec
+RSpec.describe Enigma do
+  before(:each) do
+    @enigma = Enigma.new
+  end
+
+  describe '#encrypt' do
+    it 'can encrypt a message with a key and date' do
+      expect(@enigma.encrypt('hello world', '02715', '040895')).to eq 
+      {
+        encryption: 'keder ohulw',
+        key: '02715',
+        date: '040895'
+      }
+    end
+
+    it "can encrypt a message with a key (uses today's date)" do
+      expect(@enigma.enigma.encrypt('hello world', '02715')).to eq 
+      {
+        encryption: 'keder ohulw',
+        key: '02715',
+        date: '040895'
+      }
+    end
+
+    it "can encrypt a message (generates random key and uses today's date)" do
+      expect(enigma.encrypt('hello world')).to eq
+      {
+        encryption: 'keder ohulw',
+        key: '02715',
+        date: '040895'
+      }
+    end
+  end
+
+  describe '#decrypt' do
+    it 'can decrypt a message with a key and date' do
+      expect(@enigma.decrypt('keder ohulw', '02715', '040895')).to eq
+      {
+        encryption: 'hello world',
+        key: '02715',
+        date: '040895'
+      }
+    end
+
+    it "can decrypt a message with a key (uses today's date)" do
+      encrypted = enigma.encrypt('hello world', '02715')
+      expect(@enigma.decrypt(encrypted[:encryption], '02715')).to eq
+      {
+        encryption: 'hello world',
+        key: '02715',
+        date: '040895'
+      }
+    end
+  end
+
+  # describe '#crack' do
+  # end
+end


### PR DESCRIPTION
Chunked basic functionality into one branch. further branches will be like command_interface, crack, and inheritance_refactor perhaps. 

I realized the only difference between the encode and decode algorithms was a single sign in the meat of the method, so I allowed #code to accept an argument of 1 or -1 that changes the sign of that bit, making it much DRYer. 

Tried to write a format method to format the encrypt return hash but it was nonfunctional and it would have defeated the point to fix it